### PR TITLE
Update Checkout.jsx

### DIFF
--- a/extensions/read-custom-data/src/Checkout.jsx
+++ b/extensions/read-custom-data/src/Checkout.jsx
@@ -4,6 +4,7 @@ import {
   useCartLineTarget,
   Text,
   useAppMetafields,
+  reactExtension,
 } from "@shopify/ui-extensions-react/checkout";
 // [END read-custom-data.imports]
 


### PR DESCRIPTION
Adds a missing `reactExtension` import to the example. Thanks for pointing this out @nickwesselman!